### PR TITLE
Start page styling tweak suggestions

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1,5 +1,5 @@
 body{
-    font-family:'Samsung One'; 
+    font-family:'Samsung One';
     color:white;
 }
 
@@ -8,15 +8,24 @@ body{
     height: 100%;
     background-color: #2196F3;
     position: absolute;
-    top: 0px;
-    left: 0px;
+    top: 0;
+    left: 0;
     z-index:10;
 }
 
 #maincontent{
     margin:auto;
-    padding:1em;
+    padding: 2em 1em;
     width: 25em;
+    font-size: 1.2em;
+}
+
+#moreInfo {
+    margin: 2em 0;
+}
+
+#moreInfo .flexRow {
+    margin-top: 2em;
 }
 
 #logo{
@@ -26,10 +35,9 @@ body{
 }
 
 #silogo{
-    margin: auto;
     display: block;
     width: 6em;
-    margin-top: .5em;
+    margin: 2em auto 0 auto;
 }
 
 #moreIco{
@@ -48,7 +56,7 @@ body{
 }
 
 .btn{
-    border: 2 solid #fff;
+    border: 2px solid #fff;
     padding: .2em;
     border-radius: 1em;
     cursor: pointer;
@@ -58,7 +66,7 @@ body{
 
 a:link, a:hover, a:visited, a:active{
     color: #fff;
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 /*small sized screen*/
@@ -70,21 +78,20 @@ a:link, a:hover, a:visited, a:active{
     }
 
     body{
-        font-family:'Samsung One'; 
+        font-family:'Samsung One';
         color:white;
         font-size: 0.8em;
     }
-    
+
     #logo{
         margin: auto;
         display: block;
         width: 15em;
     }
-    
+
     #silogo{
-        margin: auto;
         display: block;
         width: 6em;
-        margin-top: .5em;
+        margin: 1em auto;
     }
 }


### PR DESCRIPTION
Hey @diekus. When screenshotting this for our presentation, I thought that the text might be a bit small to read... Here's some suggested tweaks...

Before:

<img width="300px" src="https://user-images.githubusercontent.com/151207/38470109-380d5d6e-3b56-11e8-945d-c36402fb7c0e.png"/>

After:

<img width="300px" src="https://user-images.githubusercontent.com/151207/38470112-463f630a-3b56-11e8-9102-fdc4a5a1a7a2.png"/>


NB. I didn't add the button borders, but they seemed to appear after I added some padding.

What do you think? Cheers.